### PR TITLE
Bump the version and update source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "karma-source-map-support",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Karma plugin for inline sourcemap support",
   "main": "lib/index.js",
   "dependencies": {
-    "source-map-support": "^0.2.8"
+    "source-map-support": "^0.3.2"
   },
   "homepage": "https://github.com/tschaub/karma-source-map-support",
   "author": {


### PR DESCRIPTION
`node-source-map-support` has fixed some major bugs including fixing support for inline source maps.
