### PR TITLE
Update source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Karma plugin for inline sourcemap support",
   "main": "lib/index.js",
   "dependencies": {
-    "source-map-support": "^0.2.8"
+    "source-map-support": "^0.3.2"
   },
   "homepage": "https://github.com/tschaub/karma-source-map-support",
   "author": {


### PR DESCRIPTION
This brings in the latest `source-map-support` package.

Fixes #3.
