### PR TITLE
build: update source-map-support to be compatible with source-map 0.6.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "karma-source-map-support",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Karma plugin for inline sourcemap support",
   "main": "lib/index.js",
   "dependencies": {
-    "source-map-support": "^0.4.1"
+    "source-map-support": "~0.5.3"
   },
   "homepage": "https://github.com/tschaub/karma-source-map-support",
   "author": {


### PR DESCRIPTION
Update dependency explicitly on - https://github.com/evanw/node-source-map-support/blob/master/package.json to be compatible with source-map 0.6.0+ 